### PR TITLE
Add scoring system

### DIFF
--- a/pong.c
+++ b/pong.c
@@ -55,6 +55,12 @@ static void reset_ball(signed char dir) {
 static void show_winner(byte player) {
     const char *msg = player == 1 ? p1_win : p2_win;
     byte i = 0;
+
+    /* draw the final score so the screen shows the winning value */
+    oam_off = 0;
+    draw_score();
+    oam_hide_rest(oam_off);
+
     ppu_off();
     vram_adr(NTADR_A(12, 14));
     while (msg[i]) {
@@ -62,7 +68,8 @@ static void show_winner(byte player) {
         ++i;
     }
     ppu_on_all();
-    while (1) ppu_wait_nmi();
+    while (1)
+        ppu_wait_nmi();
 }
 
 static void check_winner(void) {

--- a/pong.c
+++ b/pong.c
@@ -15,6 +15,7 @@ static Sprite ball;
 static signed char ball_vx;
 static signed char ball_vy;
 static byte pad1, pad2;
+static byte score_l, score_r;
 #pragma data-name(pop)
 #pragma  bss-name(pop)
 
@@ -31,6 +32,44 @@ static const byte palette[32] = {
     0x0f,0x11,0x21,0x31,
 };
 
+static const char p1_win[] = "P1 WINS!";
+static const char p2_win[] = "P2 WINS!";
+
+static void draw_score(void) {
+    byte t;
+    t = score_l / 10;
+    oam_off = oam_spr(112, 16, '0' + t, 0, oam_off);
+    t = score_l % 10;
+    oam_off = oam_spr(120, 16, '0' + t, 0, oam_off);
+    t = score_r / 10;
+    oam_off = oam_spr(144, 16, '0' + t, 0, oam_off);
+    t = score_r % 10;
+    oam_off = oam_spr(152, 16, '0' + t, 0, oam_off);
+}
+
+static void reset_ball(signed char dir) {
+    ball.x = 120; ball.y = 120;
+    ball_vx = dir; ball_vy = 1;
+}
+
+static void show_winner(byte player) {
+    const char *msg = player == 1 ? p1_win : p2_win;
+    byte i = 0;
+    ppu_off();
+    vram_adr(NTADR_A(12, 14));
+    while (msg[i]) {
+        vram_put(msg[i]);
+        ++i;
+    }
+    ppu_on_all();
+    while (1) ppu_wait_nmi();
+}
+
+static void check_winner(void) {
+    if (score_l >= 11 && score_l >= score_r + 2) show_winner(1);
+    if (score_r >= 11 && score_r >= score_l + 2) show_winner(2);
+}
+
 
 void main(void) {
     ppu_off();
@@ -40,6 +79,7 @@ void main(void) {
     paddle_r.x = 232; paddle_r.y = 112;
     ball.x = 120;     ball.y = 120;
     ball_vx = 1;      ball_vy = 1;
+    score_l = 0;      score_r = 0;
 
     oam_clear();
     ppu_on_all();
@@ -73,7 +113,15 @@ void main(void) {
             }
         }
 
-        if (ball.x <= 0 || ball.x >= 248) ball_vx = -ball_vx;
+        if (ball.x <= 0) {
+            ++score_r;
+            check_winner();
+            reset_ball(-1);
+        } else if (ball.x >= 248) {
+            ++score_l;
+            check_winner();
+            reset_ball(1);
+        }
 
         oam_off = 0;
         oam_off = oam_spr(paddle_l.x, paddle_l.y, '|', 0, oam_off);
@@ -81,6 +129,7 @@ void main(void) {
         oam_off = oam_spr(paddle_r.x, paddle_r.y, '|', 0, oam_off);
         oam_off = oam_spr(paddle_r.x, paddle_r.y + 8, '|', 0, oam_off);
         oam_off = oam_spr(ball.x, ball.y, 'o', 0, oam_off);
+        draw_score();
         oam_hide_rest(oam_off);
 
         ppu_wait_nmi();


### PR DESCRIPTION
## Summary
- add game score tracking with win conditions
- draw current scores using sprites
- stop play once one player wins (first to 11 and lead by 2)

## Testing
- `ninja`

------
https://chatgpt.com/codex/tasks/task_e_6855fc9113c483269e0dcdf18da8fd07